### PR TITLE
Switch mydumper command to Async call

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ mydumper_backup_slack:
   msg: undefined # not required. Message to send. Note that the module does not handle escaping characters. Plain-text angle brackets and ampersands should be converted to HTML entities (e.g. & to &amp;) before sending. See Slack's documentation (U(https://api.slack.com/docs/message-formatting)) for more.
   validate_certs: yes # not required. If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
   channel: undefined # not required. Channel to send the message to. If absent, the message goes to the channel selected for the I(token).
+
+# Optional Async Variables, please change only if you understand ansible async calls.
+
+mydumper_async: 30_000       
+mydumper_async_retries: 500
+mydumper_async_delay: 60
 ```
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,8 @@
 mydumper_backup_console_base_url: https://s3.console.aws.amazon.com/s3/buckets
 #mydumper_backup_slack:
 #mydumper_backup:
+
+
+mydumper_async: 30_000
+mydumper_async_retries: 500
+mydumper_async_delay: 60

--- a/tasks/mydumper.yml
+++ b/tasks/mydumper.yml
@@ -1,5 +1,16 @@
-- name:  Run mydumper command
+- name:  Run Mydumper command (Async)
   shell: '{{ lookup("template", "mydumper_command.j2") }}'
+  async: '{{ mydumper_async }}'
+  poll: 0
+  register: mydumper_command_info
+
+- name: Wait until Mydumper command is finished
+  async_status:
+      jid: '{{ mydumper_command_info.ansible_job_id }}'
+  register: mydumper_command_result
+  until: mydumper_command_result.finished
+  retries: '{{ mydumper_async_retries }}'
+  delay: '{{ mydumper_async_delay }}'
 
 - name: Create new variable with output dir location
   set_fact:


### PR DESCRIPTION
PR switches from a normal Ansible command to an async one, this should stress AWX less due to not having to maintain an open connection during a long mysql dump.